### PR TITLE
Add background-floating color for new user view

### DIFF
--- a/index.css
+++ b/index.css
@@ -4,6 +4,7 @@
     --background-secondary: #1d1d1d !important;
     --background-tertiary: #181818 !important;
     --background-text-area: #292929 !important;
+    --background-floating: #1f1f1f !important;
     --scrollbar-auto-track: rgb(41, 41, 41);
     --scrollbar-auto-thumb: rgb(77, 77, 77);
     --container-hover: rgb(58, 58, 58);

--- a/powercord_manifest.json
+++ b/powercord_manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "ForgottenKeep",
     "description": "The dark theme, that everyone has wondered about, is finally here!",
-    "version": "2.8",
+    "version": "2.9",
     "author": "Awish#6969",
     "theme": "index.css",
     "license": "MIT"


### PR DESCRIPTION
Add a custom color to background-floating. 
This variable is used since the last Discord update for the minimal user view background (when you click on the name or avatar of someone).